### PR TITLE
Fix for racecondition with input devices

### DIFF
--- a/example/actions/input.act
+++ b/example/actions/input.act
@@ -2,4 +2,3 @@
 event=any
 OS_SUBSYSTEM=input
 helper=input.sh
-daemonlet=true


### PR DESCRIPTION
I think it is best for now to run input.act without the  deamonlet option
to avoid a race condition. 

More information in issue #71 